### PR TITLE
Require tfl api keys to run

### DIFF
--- a/app/tfl/api.rb
+++ b/app/tfl/api.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 require "songkick/transport"
+require "prius"
+
+Prius.load(:tfl_application_id)
+Prius.load(:tfl_application_key)
 
 module Tfl
   module Api
@@ -109,7 +113,7 @@ module Tfl
       end
 
       def status_by_mode(mode)
-        @client.get("/line/mode/#{mode}/status").data.map do |line|
+        @client.get("/line/mode/#{mode}/status", app_key_args).data.map do |line|
           Tfl::Line.from_api(line)
         end
       rescue Songkick::Transport::HttpError => exception
@@ -121,7 +125,7 @@ module Tfl
       end
 
       def status_by_id(id)
-        json = @client.get("/line/#{id}/status").data
+        json = @client.get("/line/#{id}/status", app_key_args).data
         if json.empty?
           # TfL might return an empty list sometimes for uncommon ids such as
           # 'cycle-hire' or 'walking'.
@@ -137,6 +141,13 @@ module Tfl
       end
 
       private
+
+      def app_key_args
+        {
+          app_id: Prius.get(:tfl_application_id),
+          app_key: Prius.get(:tfl_application_key)
+        }
+      end
 
       def transport
         Songkick::Transport::Curb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ $LOAD_PATH.unshift File.expand_path("../../app", __FILE__)
 
 ENV["DISCORD_CLIENT_ID"] = "12345678901234567"
 ENV["DISCORD_TOKEN"] = "t0k3nt0k3nt0k3nt0k3nt0k3n.1234hrx0rz1234token"
+ENV["TFL_APPLICATION_ID"] = "tfl-application-id"
+ENV["TFL_APPLICATION_KEY"] = "tfl-application-key"
 
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow_localhost: true)
@@ -14,21 +16,6 @@ end
 
 def load_fixture_obj(fixture_name)
   JSON.parse(load_fixture(fixture_name))
-end
-
-def stub_tfl_response(path, fixture, status = 200)
-  stub_request(:get, "https://api.tfl.gov.uk#{path}").
-    to_return(status: status, body: load_fixture(fixture), headers: {
-      "Content-Type": "application/json; charset=utf-8"
-    })
-end
-
-def stub_tfl_not_found(path)
-  stub_request(:get, "https://api.tfl.gov.uk#{path}").to_return(status: 404)
-end
-
-def stub_tfl_invalid(path)
-  stub_request(:get, "https://api.tfl.gov.uk#{path}").to_return(status: 400)
 end
 
 RSpec.configure do |config|

--- a/spec/tfl/api_spec.rb
+++ b/spec/tfl/api_spec.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 require "spec_helper"
 
+def tfl_api_path(path)
+  %r{^https:\/\/api.tfl.gov.uk#{path}\?app_id=[\S]+app_key=[\S]+}
+end
+
+def stub_tfl_response(path, fixture, status = 200)
+  stub_request(:get, tfl_api_path(path)).
+    to_return(status: status, body: load_fixture(fixture), headers: {
+      "Content-Type": "application/json; charset=utf-8"
+    })
+end
+
+def stub_tfl_not_found(path)
+  stub_request(:get, tfl_api_path(path)).to_return(status: 404)
+end
+
+def stub_tfl_invalid(path)
+  stub_request(:get, tfl_api_path(path)).to_return(status: 400)
+end
+
 RSpec.describe Tfl::Api::Client do
   let(:instance) { described_class.new }
 


### PR DESCRIPTION
This does not seem strictly necessary as it looks like we can still make API requests without the necessary keys, but I believe it's against the ToS and anyway there might be some aggressive rate limiting otherwise.
