### PR TITLE
Raise a known exception when dealing with malformed data

### DIFF
--- a/app/tfl/api.rb
+++ b/app/tfl/api.rb
@@ -110,7 +110,7 @@ module Tfl
 
       def status_by_mode(mode)
         @client.get("/line/mode/#{mode}/status").data.map do |line|
-          Tfl::Line.from_json(line)
+          Tfl::Line.from_api(line)
         end
       rescue Songkick::Transport::HttpError => exception
         if [400, 404].include? exception.status
@@ -127,7 +127,7 @@ module Tfl
           # 'cycle-hire' or 'walking'.
           return nil
         end
-        Tfl::Line.from_json(json.first)
+        Tfl::Line.from_api(json.first)
       rescue Songkick::Transport::HttpError => exception
         if [400, 404].include? exception.status
           raise Tfl::InvalidLineException

--- a/app/tfl/line.rb
+++ b/app/tfl/line.rb
@@ -2,12 +2,20 @@
 module Tfl
   class InvalidLineException < StandardError; end
 
+  # A "line" is an in-memory representation of a given TfL service such as a
+  # tube line, a bus route, a boat service or others.
   class Line
     attr_reader :id, :display_name, :mode, :disruptions, :current_status
 
-    def self.from_json(json)
+    def self.from_api(api_obj)
+      requires_key(api_obj, "id")
+      requires_key(api_obj, "name")
+      requires_key(api_obj, "modeName")
+      requires_key(api_obj, "lineStatuses")
+      requires_key(api_obj["lineStatuses"].first, "statusSeverityDescription")
+
       disruptions = []
-      json["lineStatuses"].each do |status|
+      api_obj["lineStatuses"].each do |status|
         if status.key?("disruption")
           disruptions << status["disruption"]["description"]
         end
@@ -18,16 +26,21 @@ module Tfl
       # since if there's no good service (and therefore there is at least
       # one disruption), showing the first disruptions' type is generally
       # enough to determine that there isn't good service on the line.
-      current_status = json["lineStatuses"].first["statusSeverityDescription"]
+      current_status = api_obj["lineStatuses"].first["statusSeverityDescription"]
 
       new(
-        id: json["id"],
-        display_name: json["name"],
-        mode: json["modeName"],
+        id: api_obj["id"],
+        display_name: api_obj["name"],
+        mode: api_obj["modeName"],
         current_status: current_status,
         disruptions: disruptions
       )
     end
+
+    def self.requires_key(obj, key)
+      raise InvalidLineException unless obj.include?(key)
+    end
+    private_class_method :requires_key
 
     def initialize(id:, display_name:, mode:, current_status:, disruptions: [])
       @id = id

--- a/spec/tfl/line_spec.rb
+++ b/spec/tfl/line_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Tfl::Line do
+  describe "#from_api" do
+    subject(:line) { described_class.from_api(api_obj) }
+    let(:api_obj) { load_fixture_obj("tfl/status_central_good_service").first }
+
+    it "creates a new valid object" do
+      expect(line.id).to eq("central")
+      expect(line.mode).to eq("tube")
+      expect(line.current_status).to eq("Good Service")
+      expect(line.display_name).to eq("Central")
+      expect(line.good_service?).to be true
+      expect(line.disruptions).to be_empty
+    end
+
+    context "when given an invalid object" do
+      let(:api_obj) { { x: "y" } }
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(Tfl::InvalidLineException)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Useful in case TfL returns an invalid response or (more likely) we pass
the wrong object to `Line.from_api`.