### PR TITLE
Flush stdout after every messsage

### DIFF
--- a/app/loggy.rb
+++ b/app/loggy.rb
@@ -4,6 +4,7 @@ require "logger"
 module Loggy
   def logger
     if @logger.nil?
+      $stdout.sync = true
       @logger = Logger.new(STDOUT)
       @logger.level = Logger::INFO
 


### PR DESCRIPTION
As we have multiple threads competing for stdout, if we don't flush
stdout after every message we end up with messages overlapping each
other.