### PR TITLE
Better line support and testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'discordrb', '~> 3.0.2'
 
 group :development do
   gem 'rspec', '~> 3.4.0'
+  gem 'factory_girl', '~> 4.7.0'
   gem 'rubocop', '~> 0.43.0'
   gem 'webmock', '~> 2.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     event_emitter (0.2.5)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
     ffi (1.9.14)
     hashdiff (0.3.0)
     http-cookie (1.0.3)
@@ -99,6 +101,7 @@ PLATFORMS
 DEPENDENCIES
   curb (~> 0.9.3)
   discordrb (~> 3.0.2)
+  factory_girl (~> 4.7.0)
   levenshtein-ffi (~> 1.1.0)
   prius (~> 1.0)
   rspec (~> 3.4.0)

--- a/app/tfl/line.rb
+++ b/app/tfl/line.rb
@@ -50,6 +50,12 @@ module Tfl
       @disruptions = disruptions
     end
 
+    def ==(other)
+      @id == other.id
+    end
+
+    alias_method :eql?, :==
+
     def good_service?
       disruptions.empty?
     end

--- a/app/tfl/line.rb
+++ b/app/tfl/line.rb
@@ -29,7 +29,7 @@ module Tfl
       current_status = api_obj["lineStatuses"].first["statusSeverityDescription"]
 
       new(
-        id: api_obj["id"],
+        id: api_obj["id"].to_sym,
         display_name: api_obj["name"],
         mode: api_obj["modeName"],
         current_status: current_status,

--- a/spec/factories/line.rb
+++ b/spec/factories/line.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :line, class: Tfl::Line do
+    id :central
+    display_name "Central"
+    mode "tube"
+    current_status "Good Service"
+    disruptions []
+
+    initialize_with do
+      new(id: id,
+          display_name: display_name,
+          mode: mode,
+          current_status: current_status,
+          disruptions: disruptions)
+    end
+
+    trait :central do
+      id :central
+      display_name "Central"
+    end
+
+    trait :circle do
+      id :circle
+      display_name "Circle"
+    end
+
+    trait :northern do
+      id :northern
+      display_name "Northern"
+    end
+
+    trait :good_service do
+      current_status "Good Service"
+      disruptions []
+    end
+
+    trait :planned_closure do
+      current_status "Planned Closure"
+      disruptions ["Saturday 8 and Sunday 9 October, no service throughout the line."]
+    end
+
+    trait :part_closure do
+      current_status "Part Closure"
+      disruptions ["Saturday 8 and Sunday 9 October, " \
+        "no service between Embankment and Dagenham East. Replacement buses operate"]
+    end
+
+    trait :service_closed do
+      current_status "Service Closed"
+      disruptions ["Train service resumes Monday Morning at 0615"]
+    end
+
+    trait :special_service do
+      current_status "Special Service"
+      disruptions ["Buses in the Canada Water, Limehouse, London Bridge, Southwark, " \
+        "Tower Hill and Waterloo areas delayed up to forty minutes and some services " \
+        "may terminate early due to the planned closure of Tower Bridge. Allow extra " \
+        "time for your journey and follow @TfLBusAlerts on Twitter for " \
+        "realtime information."]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ ENV["DISCORD_TOKEN"] = "t0k3nt0k3nt0k3nt0k3nt0k3n.1234hrx0rz1234token"
 ENV["TFL_APPLICATION_ID"] = "tfl-application-id"
 ENV["TFL_APPLICATION_KEY"] = "tfl-application-key"
 
+require "factory_girl"
+
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -25,6 +27,10 @@ def load_fixture_obj(fixture_name)
 end
 
 RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+
+  config.before(:suite) { FactoryGirl.find_definitions }
+
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end

--- a/spec/tfl/api_spec.rb
+++ b/spec/tfl/api_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Tfl::Api::Client do
           end
 
           it "has the central line" do
-            expect(api_call.id).to eq("central")
+            expect(api_call.id).to eq(:central)
           end
 
           it "has good service" do
@@ -64,7 +64,7 @@ RSpec.describe Tfl::Api::Client do
           end
 
           it "has the circle line" do
-            expect(api_call.id).to eq("circle")
+            expect(api_call.id).to eq(:circle)
           end
 
           it "has disruptions" do
@@ -88,7 +88,7 @@ RSpec.describe Tfl::Api::Client do
           end
 
           it "has the dlr" do
-            expect(api_call.id).to eq("dlr")
+            expect(api_call.id).to eq(:dlr)
           end
 
           it "has disruptions" do

--- a/spec/tfl/line_spec.rb
+++ b/spec/tfl/line_spec.rb
@@ -23,4 +23,20 @@ RSpec.describe Tfl::Line do
       end
     end
   end
+
+  describe "#==" do
+    let(:line1) { FactoryGirl.build(:line, :central) }
+    let(:line2) { FactoryGirl.build(:line, :northern) }
+    let(:line3) { FactoryGirl.build(:line, :central) }
+
+    it "returns true for the same line" do
+      expect(line1 == line3).to be true
+      expect(line3 == line1).to be true
+    end
+
+    it "returns false for different lines" do
+      expect(line1 == line2).to be false
+      expect(line2 == line1).to be false
+    end
+  end
 end

--- a/spec/tfl/line_spec.rb
+++ b/spec/tfl/line_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Tfl::Line do
     let(:api_obj) { load_fixture_obj("tfl/status_central_good_service").first }
 
     it "creates a new valid object" do
-      expect(line.id).to eq("central")
+      expect(line.id).to eq(:central)
       expect(line.mode).to eq("tube")
       expect(line.current_status).to eq("Good Service")
       expect(line.display_name).to eq("Central")


### PR DESCRIPTION
Use symbols rather than strings for line identifiers. Also introduce testing traits for lines, as a basis for supporting streaming of event changes.