### PR TITLE
Do not announce strikes when TfL returns an empty page

### DIFF
--- a/app/bot/tasks/announce_new_strikes.rb
+++ b/app/bot/tasks/announce_new_strikes.rb
@@ -25,8 +25,7 @@ module Bot
         CONFIG.pr_announce_channels_ids.each do |channel_id|
           bot.send_message(
             channel_id,
-            "New press release from TfL: #{strike.title}. " \
-              "Read more at #{strike.url}",
+            "**New press release from TfL**: #{strike.title}. Read more at #{strike.url}",
           )
         end
       end

--- a/app/tfl/scraping/press_releases_feed.rb
+++ b/app/tfl/scraping/press_releases_feed.rb
@@ -32,7 +32,7 @@ module Tfl
           return false
         end
 
-        has_changed = new_releases != @releases
+        has_changed = !new_releases.empty? && new_releases != @releases
         if has_changed
           @releases = new_releases
           true

--- a/app/tfl/scraping/press_releases_feed.rb
+++ b/app/tfl/scraping/press_releases_feed.rb
@@ -10,8 +10,8 @@ module Tfl
     PressRelease = Struct.new(:title, :url)
 
     class PressReleasesFeed
-      def initialize
-        @releases = []
+      def initialize(releases: [])
+        @releases = releases
       end
 
       def strikes
@@ -21,11 +21,24 @@ module Tfl
       attr_reader :releases
 
       def update!(raw_html: nil)
-        new_releases = parse_content(raw_html || download_content)
-        changed = new_releases != @releases
-        @releases = new_releases
+        update_from_list(parse_content(raw_html || download_content))
+      end
 
-        changed
+      def update_from_list(new_releases)
+        if @releases.empty?
+          # We need to special case the first update since we want to update the list but
+          # pretend it did not actually change.
+          @releases = new_releases
+          return false
+        end
+
+        has_changed = new_releases != @releases
+        if has_changed
+          @releases = new_releases
+          true
+        else
+          false
+        end
       end
 
       private
@@ -40,7 +53,7 @@ module Tfl
         items = doc.search("div.vertical-button-container a.plain-button")
         items.map do |item|
           # There's a "<br>" between the title and the date that makes
-          # this necessary :()
+          # this necessary :(
           title = item.children.first.text.strip
           relative_url = item["href"]
 

--- a/spec/tfl/scraping/press_releases_feed_spec.rb
+++ b/spec/tfl/scraping/press_releases_feed_spec.rb
@@ -82,5 +82,12 @@ RSpec.describe Tfl::Scraping::PressReleasesFeed do
       ])
     end
     # rubocop:enable Metrics/LineLength
+
+    context "when TfL returns an empty list" do
+      it "doesn't update the current list" do
+        expect(instance.update_from_list([])).to be false
+        expect(instance.strikes).to_not be_empty
+      end
+    end
   end
 end

--- a/spec/tfl/scraping/press_releases_feed_spec.rb
+++ b/spec/tfl/scraping/press_releases_feed_spec.rb
@@ -3,10 +3,38 @@
 require "spec_helper"
 
 RSpec.describe Tfl::Scraping::PressReleasesFeed do
-  let(:instance) { described_class.new }
+  let(:instance) { described_class.new(releases: releases) }
+  let(:releases) { [] }
   let!(:raw_html) { load_fixture("tfl/press-releases", type: "html") }
 
+  context "when it's the first update" do
+    let(:releases) { [] }
+    let(:dummy_list) do
+      [
+        Tfl::Scraping::PressRelease.new("Sample release", "https://google.com"),
+      ]
+    end
+
+    it "returns false when it gets the list for the first time" do
+      expect(instance.update_from_list(dummy_list)).to be false
+    end
+
+    context "and gets a second update that changes the list again" do
+      before { instance.update_from_list(dummy_list) }
+
+      it "returns true when updating" do
+        expect(instance.update!(raw_html: raw_html)).to be true
+      end
+    end
+  end
+
   context "when the content has changed between scans" do
+    let(:releases) do
+      [
+        Tfl::Scraping::PressRelease.new("Sample release", "https://google.com"),
+      ]
+    end
+
     it "returns true when updating" do
       expect(instance.update!(raw_html: raw_html)).to be true
     end


### PR DESCRIPTION
This should fix a problem when TfL fails to return valid content for the press releases feed, which means we extract an empty list and in the next update we mistakenly assume that the list has changed. This causes a few false positives when there's a strike announcement in the list.