### PR TITLE
Show a temporary message whilst we wait for status to return

### DIFF
--- a/app/bot/discord_utils.rb
+++ b/app/bot/discord_utils.rb
@@ -19,6 +19,7 @@ module Bot
       SCREAM = ":scream:"
       SMILE = ":smile:"
       SMILEY = ":smiley:"
+      THINKING = ":thinking:"
       TOILET = ":toilet:"
 
       def self.emoji?(word)


### PR DESCRIPTION
This gives feedback to the user that something is happening behind the
scenes and is a better UX in case the request takes a long time to be
fulfilled.