### PR TITLE
Generate a slightly smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ ENV APK_PACKAGES build-base \
                  tzdata curl-dev \
                  ruby ruby-bundler ruby-dev ruby-json
 
-RUN apk update && \
-    apk upgrade && \
-    apk add $APK_PACKAGES && \
+RUN set -x && apk update && \
+    apk --no-cache add $APK_PACKAGES && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir /app
@@ -15,7 +14,7 @@ WORKDIR /app
 
 COPY Gemfile /app/
 COPY Gemfile.lock /app/
-RUN bundle install
+RUN bundle install --deployment --jobs 4 --no-cache --without development test
 
 COPY . /app
 

--- a/Dockerfile.rpi3
+++ b/Dockerfile.rpi3
@@ -1,15 +1,13 @@
 FROM arm32v6/alpine:3.8
 MAINTAINER Ivan Giuliani <giuliani.v@gmail.com>
-
 COPY ./qemu-arm-static /usr/bin/qemu-arm-static
 
 ENV APK_PACKAGES build-base \
                  tzdata curl-dev \
                  ruby ruby-bundler ruby-dev ruby-json
 
-RUN apk update && \
-    apk upgrade && \
-    apk add $APK_PACKAGES && \
+RUN set -x && apk update && \
+    apk --no-cache add $APK_PACKAGES && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir /app
@@ -17,7 +15,7 @@ WORKDIR /app
 
 COPY Gemfile /app/
 COPY Gemfile.lock /app/
-RUN bundle install
+RUN bundle install --deployment --jobs 4 --no-cache --without development test
 
 COPY . /app
 


### PR DESCRIPTION
Avoid including development and testing dependencies in the final docker
build.