### PR TITLE
Do not use a globally instantiated API client

### DIFF
--- a/app/bot/commands/bus.rb
+++ b/app/bot/commands/bus.rb
@@ -9,6 +9,10 @@ module Bot
 
       COMMAND = :bus
 
+      def initialize(tfl_api_client: Bot.default_tfl_api_client)
+        @tfl_api_client = tfl_api_client
+      end
+
       def self.execute(event)
         BusCommand.new.execute(event)
       end
@@ -25,7 +29,7 @@ module Bot
         log "[command/bus(from:#{event.user.name})] #{bus_line}"
 
         begin
-          bus = TFL.bus_route(bus_line.strip)
+          bus = tfl_api_client.bus_route(bus_line.strip)
 
           # \u2192 is a unicode right arrow. The double-ended arrow which would arguably
           # be more correct in this case is displayed as an emoji in Discord for reasons
@@ -45,6 +49,10 @@ module Bot
       def valid_query?(args)
         args.count == 1 && Tfl::Const::Bus::ALL.include?(args.first.strip.downcase)
       end
+
+      private
+
+      attr_reader :tfl_api_client
     end
   end
 end

--- a/app/bot/commands/situation.rb
+++ b/app/bot/commands/situation.rb
@@ -9,6 +9,10 @@ module Bot
 
       COMMAND = :situation
 
+      def initialize(tfl_api_client: Bot.default_tfl_api_client)
+        @tfl_api_client = tfl_api_client
+      end
+
       def self.execute(event)
         SituationCommand.new.execute(event)
       end
@@ -17,7 +21,7 @@ module Bot
         log "[command/situation(from:#{event.user.name})]"
 
         begin
-          lines = TFL.status(:by_mode, Tfl::Const::Mode::METROPOLITAN_TRAINS)
+          lines = tfl_api_client.status(:by_mode, Tfl::Const::Mode::METROPOLITAN_TRAINS)
         rescue Songkick::Transport::TimeoutError
           event << "#{DiscordUtils::Emoji::SCREAM} Request timed out (blame TfL)"
           return
@@ -31,6 +35,8 @@ module Bot
       end
 
       private
+
+      attr_reader :tfl_api_client
 
       def severity_string(severity)
         if severity >= 1.0

--- a/app/bot/commands/status.rb
+++ b/app/bot/commands/status.rb
@@ -12,6 +12,10 @@ module Bot
       MAX_LIST_RESPONSE_COUNT = 30
       MAX_QUERY_LENGTH = 42
 
+      def initialize(tfl_api_client: Bot.default_tfl_api_client)
+        @tfl_api_client = tfl_api_client
+      end
+
       def self.execute(event, mention: false)
         StatusCommand.new.execute(event, mention: mention)
       end
@@ -70,9 +74,13 @@ module Bot
         [type, entity]
       end
 
+      private
+
+      attr_reader :tfl_api_client
+
       def format_response(type, entity)
         begin
-          response = TFL.status(type, entity)
+          response = tfl_api_client.status(type, entity)
         rescue Tfl::InvalidLineException
           return "Woops, that is not a line I recognise"
         rescue Songkick::Transport::TimeoutError

--- a/app/bot/tflbot.rb
+++ b/app/bot/tflbot.rb
@@ -14,7 +14,10 @@ Prius.load(:discord_token)
 
 module Bot
   CONFIG = Config.new
-  TFL = Tfl::Api::Client.new
+
+  def self.default_tfl_api_client
+    @default_tfl_api_client ||= Tfl::Api::Client.new
+  end
 
   class LondonBot
     include Loggy


### PR DESCRIPTION
Rather, have an explicit instance of the TfL api client passed down to
consumers so that we can more easily mock out API calls if necessary.