### PR TITLE
Correctly resolve waterloo & city

### DIFF
--- a/app/tfl/id_resolver.rb
+++ b/app/tfl/id_resolver.rb
@@ -23,6 +23,7 @@ module Tfl
       "southwestern" => "south-west-trains",
       "victoria line" => Tfl::Const::Tube::VICTORIA,
       "waterloo" => Tfl::Const::Tube::WATERLOO,
+      "waterloo & city" => Tfl::Const::Tube::WATERLOO,
       "waterloo and city" => Tfl::Const::Tube::WATERLOO,
       "w&c" => Tfl::Const::Tube::WATERLOO,
     }.freeze


### PR DESCRIPTION
Turns out that there was no variant with the ampersand in the list we
get from tfl and therefore we cannot resolve the line's name correctly
when given in input.