### PR TITLE
Use HttParty as transport layer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rufus-scheduler", "~> 3.6.0"
 gem "sentry-raven", "~> 2.12.0", require: "sentry-raven-without-integrations"
 
 # Transport
-gem "curb", "~> 0.9.10" # HTTP transport library
+gem "httparty", "~> 0.17.1" # HTTP transport library
 gem "discordrb", "~> 3.3.0"
 gem "songkick-transport", "~> 1.11.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem "rufus-scheduler", "~> 3.6.0"
 gem "sentry-raven", "~> 2.12.0", require: "sentry-raven-without-integrations"
 
 # Transport
-gem "httparty", "~> 0.17.1" # HTTP transport library
 gem "discordrb", "~> 3.3.0"
+gem "httparty", "~> 0.17.1" # HTTP transport library
 gem "songkick-transport", "~> 1.11.0"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,6 @@ GEM
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    curb (0.9.10)
     diff-lcs (1.3)
     discordrb (3.3.0)
       discordrb-webhooks (~> 3.3.0)
@@ -43,6 +42,9 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    httparty (0.17.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
@@ -54,6 +56,7 @@ GEM
     mime-types-data (3.2018.0812)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
+    multi_xml (0.6.0)
     multipart-post (2.1.1)
     netrc (0.11.0)
     nokogiri (1.10.4)
@@ -136,9 +139,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  curb (~> 0.9.10)
   discordrb (~> 3.3.0)
   factory_bot (~> 5.1.1)
+  httparty (~> 0.17.1)
   levenshtein-ffi (~> 1.1.0)
   nokogiri (~> 1.10.4)
   prius (~> 2.0)

--- a/app/tfl/api.rb
+++ b/app/tfl/api.rb
@@ -94,7 +94,7 @@ module Tfl
       end
 
       def transport
-        Songkick::Transport::Curb
+        Songkick::Transport::HttParty
       end
     end
   end


### PR DESCRIPTION
Seems like tfl is now returning a lower case content type header,
however curb is hardcoding "Content-Type" when trying to parse it (which
in turn makes the whole thing die). Switching to HttParty seem to fix it
as it will not make any assumptions on the underlying combination of
upper and lower case letters.