### PR TITLE
Add support for Prometheus metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "songkick-transport", "~> 1.11.0"
 gem "bigdecimal", "~> 2.0.0"
 
 gem "prometheus-client", "~> 2.0.0"
+gem "rack", "~> 2.0"
 
 group :development do
   gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "songkick-transport", "~> 1.11.0"
 # Required by httparty
 gem "bigdecimal", "~> 2.0.0"
 
+gem "prometheus-client", "~> 2.0.0"
+
 group :development do
   gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       pry (~> 0.10)
     public_suffix (4.0.3)
     raabro (1.1.6)
+    rack (2.2.2)
     rainbow (3.0.0)
     rake (13.0.1)
     rbnacl (3.4.0)
@@ -149,6 +150,7 @@ DEPENDENCIES
   prius (~> 2.0)
   prometheus-client (~> 2.0.0)
   pry-byebug
+  rack (~> 2.0)
   rake
   rspec (~> 3.9.0)
   rspec_junit_formatter (= 0.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     prius (2.0.0)
+    prometheus-client (2.0.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -146,6 +147,7 @@ DEPENDENCIES
   httparty (~> 0.17.3)
   nokogiri (~> 1.10.8)
   prius (~> 2.0)
+  prometheus-client (~> 2.0.0)
   pry-byebug
   rake
   rspec (~> 3.9.0)

--- a/app/bot/config.rb
+++ b/app/bot/config.rb
@@ -8,6 +8,7 @@ module Bot
     USERNAME = "TfLBot"
     GAME = nil
     PR_ANNOUNCE_CHANNELS_IDS = [].freeze
+    METRICS_PORT = nil
   end
 
   class Config
@@ -20,6 +21,9 @@ module Bot
       @username = config(cfg, "username", username)
       @game = config(cfg, "game", game)
       @pr_announce_channels_ids = config(cfg, "pr_announce_channels_ids", [])
+
+      @metrics_port = config(cfg, "metrics_port", nil)
+      @metrics_port = @metrics_port.to_i unless @metrics_port.nil?
 
       @config_loaded = true
     end
@@ -42,6 +46,10 @@ module Bot
 
     def pr_announce_channels_ids
       @pr_announce_channels_ids ||= DefaultConfig::PR_ANNOUNCE_CHANNELS_IDS
+    end
+
+    def metrics_port
+      @metrics_port ||= DefaultConfig::METRICS_PORT
     end
 
     private

--- a/app/metrics.rb
+++ b/app/metrics.rb
@@ -6,6 +6,10 @@ module Metrics
   SERVICE_NAME = "tflbot"
 
   class << self
+    def now_monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
     def counter(name:,
                 desc:,
                 labels: [])
@@ -24,6 +28,16 @@ module Metrics
         docstring: desc,
         labels: labels,
       )
+    end
+
+    def duration(metric_counter, metric_duration, labels = {})
+      start_time = now_monotonic
+      yield
+    ensure
+      elapsed = [now_monotonic - start_time, 0].max
+
+      metric_counter.increment(labels: labels)
+      metric_duration.increment(by: elapsed, labels: labels)
     end
   end
 end

--- a/app/metrics.rb
+++ b/app/metrics.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "prometheus/client"
+
+module Metrics
+  SERVICE_NAME = "tflbot"
+
+  class << self
+    def counter(name:,
+                desc:,
+                labels: [])
+      Prometheus::Client.registry.counter(
+        :"#{SERVICE_NAME}_#{name}_total",
+        docstring: desc,
+        labels: labels,
+      )
+    end
+
+    def gauge(name:,
+              desc:,
+              labels: [])
+      Prometheus::Client.registry.gauge(
+        :"#{SERVICE_NAME}_#{name}",
+        docstring: desc,
+        labels: labels,
+      )
+    end
+  end
+end

--- a/app/tfl/api.rb
+++ b/app/tfl/api.rb
@@ -15,6 +15,18 @@ module Tfl
     end
 
     class Client
+      RequestsStarted = Metrics.counter(
+        name: "tfl_api_requests_started",
+        desc: "A counter for API requests to TfL",
+        labels: [:endpoint],
+      )
+
+      RequestsDurationSeconds = Metrics.counter(
+        name: "tfl_api_requests_duration",
+        desc: "Duration of individual API requests to TfL",
+        labels: [:endpoint],
+      )
+
       def initialize
         @client = transport.new(Config::HOST,
                                 user_agent: Config::USER_AGENT,
@@ -33,35 +45,41 @@ module Tfl
       end
 
       def status_by_mode(mode)
-        client.get("/line/mode/#{mode}/status", app_key_args).data.map do |line|
-          Tfl::Line.from_api(line)
-        end
-      rescue Songkick::Transport::HttpError => e
-        if [400, 404].include? e.status
-          raise Tfl::InvalidLineException
-        else
-          raise
+        Metrics.duration(RequestsStarted, RequestsDurationSeconds,
+                         endpoint: "status_by_mode") do
+          client.get("/line/mode/#{mode}/status", app_key_args).data.map do |line|
+            Tfl::Line.from_api(line)
+          end
+        rescue Songkick::Transport::HttpError => e
+          if [400, 404].include? e.status
+            raise Tfl::InvalidLineException
+          else
+            raise
+          end
         end
       end
 
       def status_by_id(id)
-        json = client.get("/line/#{id}/status", app_key_args).data
-        if json.empty?
-          # TfL might return an empty list sometimes for uncommon ids such as
-          # 'cycle-hire' or 'walking'.
-          return []
+        Metrics.duration(RequestsStarted, RequestsDurationSeconds,
+                         endpoint: "status_by_id") do
+          json = client.get("/line/#{id}/status", app_key_args).data
+          if json.empty?
+            # TfL might return an empty list sometimes for uncommon ids such as
+            # 'cycle-hire' or 'walking'.
+            return []
+          end
+
+          # At some point in March 2017, TfL started returning the status of *all* the
+          # lines when given an invalid one in input. However given that we don't support
+          # fetching multiple line ids at the same time, so we can recognize that this has
+          # happened if we get back more than just one item.
+          # This is a temporary workaround: we should prevent these requests to be made in
+          # the first place. The response that TfL sends back is really big in this case
+          # and we can potentially/unintentionally DDoS them.
+          raise Tfl::InvalidLineException if json.length > 1
+
+          [Tfl::Line.from_api(json.first)]
         end
-
-        # At some point in March 2017, TfL started returning the status of *all* the lines
-        # when given an invalid one in input. However given that we don't support fetching
-        # multiple line ids at the same time, so we can recognize that this has happened
-        # if we get back more than just one item.
-        # This is a temporary workaround: we should prevent these requests to be made in
-        # the first place. The response that TfL sends back is really big in this case and
-        # we can potentially/unintentionally DDoS them.
-        raise Tfl::InvalidLineException if json.length > 1
-
-        [Tfl::Line.from_api(json.first)]
       rescue Songkick::Transport::HttpError => e
         if [400, 404].include?(e.status)
           raise Tfl::InvalidLineException
@@ -71,9 +89,12 @@ module Tfl
       end
 
       def bus_route(bus, direction = "inbound")
-        json = client.get("/line/#{bus.upcase}/route/sequence/#{direction}",
-                          app_key_args).data
-        Tfl::RouteSequence.from_api(json)
+        Metrics.duration(RequestsStarted, RequestsDurationSeconds,
+                         endpoint: "bus_route") do
+          json = client.get("/line/#{bus.upcase}/route/sequence/#{direction}",
+                            app_key_args).data
+          Tfl::RouteSequence.from_api(json)
+        end
       rescue Songkick::Transport::HttpError => e
         if [400, 404].include?(e.status)
           raise Tfl::InvalidRouteException

--- a/app/tflbot.rb
+++ b/app/tflbot.rb
@@ -3,6 +3,7 @@
 require_relative "ruby_overrides"
 
 require_relative "loggy"
+require_relative "metrics"
 require_relative "tfl/station"
 require_relative "tfl/stations"
 require_relative "tfl/const"

--- a/spec/bot/config_spec.rb
+++ b/spec/bot/config_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Bot::Config do
         username: [Bot::DefaultConfig::USERNAME, "username123"],
         game: [Bot::DefaultConfig::GAME, "The Game"],
         pr_announce_channels_ids: [Bot::DefaultConfig::PR_ANNOUNCE_CHANNELS_IDS, [1, 2]],
+        metrics_port: [Bot::DefaultConfig::METRICS_PORT, 1234],
       }
 
       mappings.each do |method, values|

--- a/spec/fixtures/sample_config.yml
+++ b/spec/fixtures/sample_config.yml
@@ -1,6 +1,7 @@
 command_prefix: "@"
 username: "username123"
 game: "The Game"
+metrics_port: 1234
 pr_announce_channels_ids:
 - 1
 - 2


### PR DESCRIPTION
Currently only tracks command executed and durations of API calls to TfL.