### PR TITLE
Explicitly enable cops to remove rubocop warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,6 +107,15 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Naming/VariableNumber:
   Enabled: false
 


### PR DESCRIPTION
This is getting real annoying.