### PR TITLE
Update docker & co

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ references:
 
   restore_bundle_cache: &restore_bundle_cache
     restore_cache:
-      key: discordtfl-{{ checksum "Gemfile.lock" }}-2.7.1
+      key: discordtfl-{{ checksum "Gemfile.lock" }}-2.7.2
 
   save_bundle_cache: &save_bundle_cache
     save_cache:
-      key: discordtfl-{{ checksum "Gemfile.lock" }}-2.7.1
+      key: discordtfl-{{ checksum "Gemfile.lock" }}-2.7.2
       paths:
         - vendor/bundle
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   DisplayStyleGuide: true
   ExtraDetails: true
   NewCops: disable
+  SuggestExtensions: false
 
 Layout/LineLength:
   Max: 90

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN set -x && apk update && \
     apk --no-cache add $APK_PACKAGES && \
     rm -rf /var/cache/apk/*
 
-RUN gem install bundler:2.0.2
-
 RUN mkdir /app
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-alpine3.11
+FROM ruby:2.7.2-alpine3.12
 MAINTAINER Ivan Giuliani <giuliani.v@gmail.com>
 
 ENV APK_PACKAGES build-base \


### PR DESCRIPTION
- actually point at ruby 2.7.2 when running within the docker image
- avoid installing an older version of bundler (which would be replaced later on anyway)
- shut up rubocop