### PR TITLE
Add github actions to run our CI

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,41 @@
+name: RSpec
+
+on: [push, pull_request]
+
+env:
+  RUBY_VERSION: "2.7.3"
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:${{ env.RUBY_VERSION }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: bundle install
+        run: |
+          gem install bundler
+          bundle config --global set path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run RSpec
+        run: bundle exec rspec --format progress
+
+  rubocop:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:${{ env.RUBY_VERSION }}
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions/setup-ruby@v1
+          with:
+            ruby-version: ${{ env.RUBY_VERSION }}
+        - name: bundle install
+          run: |
+            gem install bundler
+            bundle config --global set path vendor/bundle
+            bundle install --jobs 4 --retry 3
+        - name: Run RSpec
+          run: bundle exec rubocop


### PR DESCRIPTION
CircleCI is starting to be annoying as it only allows one thing to run
at a given time, which means we must explicitly serialise the test
steps. GH Actions may be useful as a backup so this adds experimental
support for it.